### PR TITLE
73 dev fix urls for codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,5 +23,7 @@ RUN apt-get update && \
     apt-get install -y docker-ce-cli docker-compose-plugin && \
     apt-get clean
 
+RUN usermod -aG docker vscode
+
 # Optional: set PowerShell as default shell
 ENV SHELL=/usr/bin/pwsh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,5 +10,18 @@ RUN apt-get update && \
     apt-get install -y powershell && \
     apt-get clean
 
+    
+# Install Docker CLI + Docker Compose plugin
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl gnupg lsb-release && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y docker-ce-cli docker-compose-plugin && \
+    apt-get clean
+
 # Optional: set PowerShell as default shell
 ENV SHELL=/usr/bin/pwsh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,19 +11,5 @@ RUN apt-get update && \
     apt-get clean
 
     
-# Install Docker CLI + Docker Compose plugin
-RUN apt-get update && \
-    apt-get install -y ca-certificates curl gnupg lsb-release && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-    echo \
-      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    apt-get update && \
-    apt-get install -y docker-ce-cli docker-compose-plugin && \
-    apt-get clean
-
-RUN usermod -aG docker vscode
-
 # Optional: set PowerShell as default shell
 ENV SHELL=/usr/bin/pwsh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# Use Ubuntu base image or compatible
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Install PowerShell
+RUN apt-get update && \
+    apt-get install -y wget apt-transport-https software-properties-common && \
+    wget -q "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb" && \
+    dpkg -i packages-microsoft-prod.deb && \
+    apt-get update && \
+    apt-get install -y powershell && \
+    apt-get clean
+
+# Optional: set PowerShell as default shell
+ENV SHELL=/usr/bin/pwsh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "My Codespace",
+  "name": "Crystal Codespace",
   "build": {
     "dockerfile": "Dockerfile"
   },
@@ -10,5 +10,13 @@
       }
     }
   },
-  "postCreateCommand": "pwsh"  // optional: test PowerShell on start
+  "postCreateCommand": "pwsh",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest"
+    }
+  },
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,12 +10,10 @@
       }
     }
   },
-  "features": {
+ "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "latest"
+      "version": "latest",
+      "mountDockerSocket": true
     }
-  },
-  "mounts": [
-    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
-  ]
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,17 +3,11 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "customizations": {
-    "vscode": {
-      "settings": {
-        "terminal.integrated.defaultProfile.linux": "PowerShell"
-      }
-    }
-  },
  "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",
       "mountDockerSocket": true
     }
-  }
+  },
+  "postCreateCommand": "pwsh ./.devcontainer/initializeEnvironment.ps1"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "My Codespace",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "PowerShell"
+      }
+    }
+  },
+  "postCreateCommand": "pwsh"  // optional: test PowerShell on start
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
       }
     }
   },
-  "postCreateCommand": "pwsh",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest"

--- a/.devcontainer/initializeEnvironment.ps1
+++ b/.devcontainer/initializeEnvironment.ps1
@@ -1,6 +1,6 @@
 $settingsPath = Join-Path $PSScriptRoot '..\website\inc\settings.php'
 (Get-Content $settingsPath) -replace 'http:', 'https:' | Set-Content $settingsPath
-(Get-Content $settingsPath) -replace 'localhost', "$($ENV:CODESPACE_NAME)-80.github.dev" | Set-Content $settingsPath
+(Get-Content $settingsPath) -replace 'localhost', "$($ENV:CODESPACE_NAME)-80.app.github.dev" | Set-Content $settingsPath
 Write-Host "Starging the website..."
 & (Join-Path $PSScriptRoot '..\scripts.ps1') start
-Write-Host "Website started you can access it at https://$($ENV:CODESPACE_NAME)-80.github.dev"
+Write-Host "Website started you can access it at https://$($ENV:CODESPACE_NAME)-80.app.github.dev"

--- a/.devcontainer/initializeEnvironment.ps1
+++ b/.devcontainer/initializeEnvironment.ps1
@@ -1,6 +1,6 @@
 $settingsPath = Join-Path $PSScriptRoot '..\website\inc\settings.php'
 (Get-Content $settingsPath) -replace 'http:', 'https:' | Set-Content $settingsPath
-(Get-Content $settingsPath) -replace 'localhost', $ENV:CODESPACE_NAME | Set-Content $settingsPath
+(Get-Content $settingsPath) -replace 'localhost', "$($ENV:CODESPACE_NAME)-80.github.dev" | Set-Content $settingsPath
 Write-Host "Starging the website..."
 & (Join-Path $PSScriptRoot '..\scripts.ps1') start
 Write-Host "Website started you can access it at https://$($ENV:CODESPACE_NAME)-80.github.dev"

--- a/.devcontainer/initializeEnvironment.ps1
+++ b/.devcontainer/initializeEnvironment.ps1
@@ -1,0 +1,6 @@
+$settingsPath = Join-Path $PSScriptRoot '..\website\inc\settings.php'
+(Get-Content $settingsPath) -replace 'http:', 'https:' | Set-Content $settingsPath
+(Get-Content $settingsPath) -replace 'localhost', $ENV:CODESPACE_NAME | Set-Content $settingsPath
+Write-Host "Starging the website..."
+& (Join-Path $PSScriptRoot '..\scripts.ps1') start
+Write-Host "Website started you can access it at https://$($ENV:CODESPACE_NAME)-80.github.dev"

--- a/scripts.ps1
+++ b/scripts.ps1
@@ -212,5 +212,5 @@ switch ($args[0]) {
     "database-snapshot" { Database-Snapshot }
     "database-dumpChanges" { Database-diffChangeLog }
     "refresh-cache" { Refresh-Cache }
-    default { Write-Host "Usage: crystal {start|stop|restart|logs|database-update|database-snapshot|database-dumpChanges}" }
+    default { Write-Host "Usage: scripts {start|stop|restart|logs|database-update|database-snapshot|database-dumpChanges}" }
 }


### PR DESCRIPTION
devcontainer was defined, which sets up the codespaces. Now they can be used and they will work (initialize script automatically replaces localhost with whatever site name is generated for codespaces.
They are not super fast to initialize, but they behave the same way as our local environments, so we we'll be able to use them for i.e. quick checks for review or something like that.
Or you know - even actual development if for some reason machine we're usually developing on is not accessible.