### PR TITLE
making database changes for account switcher

### DIFF
--- a/docker/liquibase/changelog/db.changelog.xml
+++ b/docker/liquibase/changelog/db.changelog.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
   <changeSet author="liquibase (generated)" id="1737906077484-1">
     <createTable tableName="mybb_adminlog">
@@ -3179,4 +3179,46 @@ INSERT INTO mybb_mycode (`title`,`description`,`regex`,`replacement`,`active`,`p
 INSERT INTO mybb_mycode (`title`,`description`,`regex`,`replacement`,`active`,`parseorder`) VALUES ('Info Box Out Brązowy','','\\[infobox=outb\\](.*?)\\[/infobox\\]','&lt;div class=\"notif_out_brown\"&gt;$1&lt;/div&gt;',1,0);
 INSERT INTO mybb_mycode (`title`,`description`,`regex`,`replacement`,`active`,`parseorder`) VALUES ('Ramka double brown','','\\[ramka=doubleb\\](.*?)\\[/ramka\\]','&lt;div class=\"frame_double_b\"&gt;$1&lt;/div&gt;',1,0);</sql>
   </changeSet>
+    <changeSet author="liquibase (generated)" id="1747952670676-1">
+        <addColumn tableName="mybb_posts">
+            <column defaultValueNumeric="0" name="ParentUid" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet author="liquibase (generated)" id="1747952670676-2">
+        <addColumn tableName="mybb_posts">
+            <column defaultValue="" name="NPCName" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet author="Patryk Konieczny" id="1747952670676-3">
+        <sql>
+          ALTER TABLE `mybb_forums` ADD COLUMN AllowedAccountType ENUM('All', 'Player', 'Character') NULL DEFAULT NULL;
+        </sql>
+    </changeSet>
+    <changeSet author="Patryk Konieczny" id="1747952670676-4">
+        <sql>
+          ALTER TABLE `mybb_users` ADD COLUMN `AccountType` ENUM('Player', 'Character', 'GM') NOT NULL DEFAULT 'Player';
+        </sql>
+    </changeSet>
+    <changeSet author="liquibase (generated)" id="1747952670676-5">
+        <addColumn tableName="mybb_users">
+            <column defaultValueNumeric="0" name="ParentUid" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet author="Patryk Konieczny" id="1747952670676-6">
+      <sql>
+        INSERT INTO `mybb_users` (`uid`, `username`, `password`, `salt`, `loginkey`, `email`, `postnum`, `threadnum`, `avatar`, `avatardimensions`, `avatartype`, `usergroup`, `additionalgroups`, `displaygroup`, `usertitle`, `regdate`, `lastactive`, `lastvisit`, `lastpost`, `website`, `icq`, `skype`, `google`, `birthday`, `birthdayprivacy`, `signature`, `allownotices`, `hideemail`, `subscriptionmethod`, `invisible`, `receivepms`, `receivefrombuddy`, `pmnotice`, `pmnotify`, `buddyrequestspm`, `buddyrequestsauto`, `threadmode`, `showimages`, `showvideos`, `showsigs`, `showavatars`, `showquickreply`, `showredirect`, `ppp`, `tpp`, `daysprune`, `dateformat`, `timeformat`, `timezone`, `dst`, `dstcorrection`, `buddylist`, `ignorelist`, `style`, `away`, `awaydate`, `returndate`, `awayreason`, `pmfolders`, `notepad`, `referrer`, `referrals`, `reputation`, `regip`, `lastip`, `language`, `timeonline`, `showcodebuttons`, `totalpms`, `unreadpms`, `warningpoints`, `moderateposts`, `moderationtime`, `suspendposting`, `suspensiontime`, `suspendsignature`, `suspendsigtime`, `coppauser`, `loginattempts`, `loginlockoutexpiry`, `usernotes`, `sourceeditor`, `AccountType`, `ParentUid`) VALUES ('0', 'NPC', '', '', '', '', '0', '0', '', '', '', '2', '', '0', '', '0', '0', '0', '0', '', '', '', '', '', 'all', '', '0', '0', '0', '0', '0', '0', '0', '0', '1', '0', '', '0', '0', '0', '0', '0', '0', '0', '0', '0', '', '', '', '0', '0', '', '', '0', '0', '0', '', '', '', '', '0', '0', '0', '', '', '', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '', '0', 'Character', '0');
+        UPDATE `mybb_users` SET `uid` = '0' WHERE `username` = 'NPC';
+      </sql>
+    </changeSet>
+    <changeSet author="Patryk Konieczny" id="1747952670676-7">
+      <sql>
+        UPDATE `mybb_forums` SET `AllowedAccountType` = 'All' WHERE `type` = 'f';
+      </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Database modifications:
mybb_users
AccountType - enum column with possible values: Player (default), Character, GM
ParentUId - Int(10) column that should hold uid for parent account. Parent should always be Player account. Player accounts should always have ParentUid equal to 0, indicating no parent account. Default value is 0. Character and GM accounts always should have a parent (with exception of special NPC account).

Added script that automatically adds special NPC account with uid of 0.

mybb_forums
AllowedAccountType - nullable enum column with possible values: All, Player, Character. Should be set for rows with type equal to 'f', null for others.
Added script that automatically sets "All" for all rows with type f.

mybb_posts 
Same as ParentUid in mybb_users - parent Player account of post author
NPCName - Text(120) field with name of NPC. It should contain provided name of NPC only when author is special NPC Account. It should be empty string for all other cases.
