### PR TITLE
103 feature account switcher v1 list of connected accounts in navigation

### DIFF
--- a/templates/1_crystallicum_dark_templates/header/header_welcomeblock_member.html
+++ b/templates/1_crystallicum_dark_templates/header/header_welcomeblock_member.html
@@ -46,8 +46,9 @@
 	</a>
 	<div class="av_menu">
 		<div class="items">
-			<!-- Extra account avatars will be here, with links to switch thems -->
-			<a href="/member.php?action=add_character" title="{$lang->add_character}"><i class="cp cp-add"></i></a>
+			{$navigation_characters}
+			<a href="{$mybb->settings['bburl']}/member.php?action=add_character" title="{$lang->add_character}"><i
+					class="cp cp-add"></i></a>
 			<a href="{$mybb->settings['bburl']}/member.php?action=logout&amp;logoutkey={$mybb->user['logoutkey']}"
 				title="Wyloguj się"><i class="cp cp-power"></i></a>
 		</div>
@@ -61,8 +62,9 @@
 	</a>
 	<div class="av_menu">
 		<div class="items">
-			<!-- Extra account avatars will be here, with links to switch thems -->
-			<a href="/member.php?action=add_character" title="{$lang->add_character}"><i class="cp cp-add"></i></a>
+			{$navigation_characters}
+			<a href="{$mybb->settings['bburl']}/member.php?action=add_character" title="{$lang->add_character}"><i
+					class="cp cp-add"></i></a>
 			<a href="{$mybb->settings['bburl']}/member.php?action=logout&amp;logoutkey={$mybb->user['logoutkey']}"
 				title="Wyloguj się"><i class="cp cp-power"></i></a>
 		</div>

--- a/templates/1_crystallicum_dark_templates/header/header_welcomeblock_member_account.html
+++ b/templates/1_crystallicum_dark_templates/header/header_welcomeblock_member_account.html
@@ -1,0 +1,3 @@
+<a href="{$mybb->settings['bburl']}/member.php?action=change_character&uid={$characterUid}" title="{$characterLabel}">
+    <img src="{$characterAvatar}" id="avatarheader" title="{$characterLabel}">
+</a>

--- a/website/global.php
+++ b/website/global.php
@@ -656,6 +656,9 @@ if($mybb->user['uid'] != 0)
 		eval('$pmslink = "'.$templates->get('header_welcomeblock_member_pms').'";');
 	}
 
+	require_once MYBB_ROOT.'inc/functions_accountswitcher.php';
+	$navigation_characters = get_characters_for_navigation($mybb->user, $templates);
+
 	eval('$welcomeblock = "'.$templates->get('header_welcomeblock_member').'";');
 }
 // Otherwise, we have a guest

--- a/website/inc/class_session.php
+++ b/website/inc/class_session.php
@@ -145,6 +145,24 @@ class session
 		");
 		$mybb->user = $db->fetch_array($query);
 
+		// Load parent account
+		if ($mybb->user['AccountType'] == 'Player') {
+			$mybb->user['parent'] = $mybb->user;
+		} else {
+			$mybb->user['parent'] = $db->fetch_array(
+				$db->simple_select('users', '*', 'uid='.(int)$mybb->user['ParentUid'])
+			);
+		}
+
+		// Load other character accounts
+		$uidForFilter = $mybb->user['AccountType'] == 'Player' ? $mybb->user['uid'] : $mybb->user['ParentUid'];
+
+		$mybb->user['characters'] = array();
+		$query = $db->simple_select('users', '*', 'ParentUid=' . (int)$uidForFilter, array('order_by' => 'uid'));
+		while ($character = $db->fetch_array($query)) {
+			$mybb->user['characters'][] = $character;
+		}
+
 		// Check the password if we're not using a session
 		if(!$mybb->user || empty($loginkey) || $loginkey !== $mybb->user['loginkey'])
 		{

--- a/website/inc/functions_accountswitcher.php
+++ b/website/inc/functions_accountswitcher.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Output for showing other accounts in navigation
+ * @param user User whose characters are being displayed
+ * @param templates Templates object for rendering HTML
+ * @return string HTML for the account items for navigation
+ */
+function get_characters_for_navigation($user, $templates) {
+    $accountItems = '';
+
+    if ($user['AccountType'] != 'Player') {
+        $accountItems .= generate_account_item($user['parent'], $templates);
+    }
+
+    foreach($user['characters'] as $character) {
+        if ($user['uid'] != $character['uid']) {
+            $accountItems .= generate_account_item($character, $templates);
+        }
+    }
+
+    return $accountItems;
+}
+
+/**
+ * Generate HTML for a single account item in the navigation
+ * @param character Character data to display
+ * @param templates Templates object for rendering HTML
+ * @return string HTML for the account item for navigation
+ */
+function generate_account_item($character, $templates) {
+    $characterLabel = $character['username'];
+    $characterUid = $character['uid'];
+    $characterAvatar = $character['avatar'];
+
+    $accountItem = '';
+    eval('$accountItem = "'.$templates->get('header_welcomeblock_member_account').'";');
+
+    return $accountItem;
+}
+
+/**
+ * Log in as a specific account. That specific account has to be a character or player account of provided user.
+ * @param user User data of the current user
+ * @param accountUid UID of the account to switch to
+ * @param redirectPage Page to redirect after login
+ */
+function login_as_account($user, $accountUid, $redirectPage) {
+    $targetUser = null;
+    if ($user['uid'] == $accountUid) {
+        return; // No need to switch to the same account
+    }
+
+    if ($user['parent']['uid'] == $accountUid) {
+        $targetUser = $user['parent'];
+    } else {
+        foreach ($user['characters'] as $character) {
+            if ($character['uid'] == $accountUid) {
+                $targetUser = $character;
+                break;
+            }
+        }
+    }
+
+    global $lang, $mybb;
+    if (!$targetUser) {
+        error($lang->sprintf($lang->error_invalid_character, $accountUid));
+    }
+
+    my_setcookie("mybbuser", $targetUser['uid']."_".$targetUser['loginkey'], null, true, "lax");
+    $lang->redirect_registered = $lang->sprintf($lang->redirect_registered, $mybb->settings['bbname'], htmlspecialchars_uni($user_info['username']));
+    redirect($redirectPage, $lang->redirect_registered);
+}

--- a/website/inc/languages/english/global.lang.php
+++ b/website/inc/languages/english/global.lang.php
@@ -591,3 +591,4 @@ $l['lost_passwd'] = 'Lost password?';
 $l['reg_options'] = 'Additional Options';
 $l['add_character'] = 'Add character';
 $l['character_name'] = 'Character name';
+$l['error_invalid_character'] = 'You can\'t switch to character with uid "{1}".';

--- a/website/inc/languages/polish/global.lang.php
+++ b/website/inc/languages/polish/global.lang.php
@@ -615,3 +615,4 @@ $l['boardclosed_reason'] = 'Forum jest aktualnie zamknięte z powodu prac konser
 $l['use_default'] = "Użyj domyślnego";
 $l['add_character'] = 'Dodaj postać';
 $l['character_name'] = 'Imię postaci';
+$l['error_invalid_character'] = 'Nie możesz zalogować się na postać z uid "{1}".';

--- a/website/inc/plugins/defaultavatarfix.php
+++ b/website/inc/plugins/defaultavatarfix.php
@@ -58,6 +58,15 @@ function defaultavatarfix()
 	 {
 		$mybb->user['avatar'] = $mybb->settings['useravatar'];
 	 }
+
+    if(!$mybb->user['parent']['avatar'] && !empty($mybb->settings['useravatar'])) {
+        $mybb->user['parent']['avatar'] = $mybb->settings['useravatar'];
+    }
+
+    foreach ($mybb->user['characters'] as &$character) {
+        if(!$character['avatar'] && !empty($mybb->settings['useravatar']))
+            $character['avatar'] = $mybb->settings['useravatar'];
+    }
 }
 $plugins->add_hook("global_start", "defaultavatarfix");
 ?>

--- a/website/member.php
+++ b/website/member.php
@@ -1586,7 +1586,7 @@ if($mybb->input['action'] == "do_lostpw" && $mybb->request_method == "post")
 		}
 	}
 
-	$query = $db->simple_select("users", "*", "email='".$db->escape_string($mybb->get_input('email'))."'");
+	$query = $db->simple_select("users", "*", "email='".$db->escape_string($mybb->get_input('email'))."' AND AccountType='Player'");
 	$numusers = $db->num_rows($query);
 	if($numusers < 1)
 	{

--- a/website/member.php
+++ b/website/member.php
@@ -114,12 +114,11 @@ if ($mybb->input['action'] == "do_add_character") {
 		$mybb->input['action'] = "add_character";
 	}
 	else {
+		require_once MYBB_ROOT."inc/functions_accountswitcher.php";
 		$user_info = $userhandler->insert_user();
 				
-		my_setcookie("mybbuser", $user_info['uid']."_".$user_info['loginkey'], null, true, "lax");
-
-		$lang->redirect_registered = $lang->sprintf($lang->redirect_registered, $mybb->settings['bbname'], htmlspecialchars_uni($user_info['username']));
-		redirect("index.php", $lang->redirect_registered);
+		$mybb->user['parent'] = $user_info;
+		login_as_account($mybb->user, $user_info['uid'], "index.php");
 	}
 }
 
@@ -130,6 +129,12 @@ if ($mybb->input['action'] == "add_character") {
 
 	eval("\$add_character = \"".$templates->get("member_add_character")."\";");
 	output_page($add_character);
+}
+
+if ($mybb->input['action'] == 'change_character') {
+	require_once MYBB_ROOT."inc/functions_accountswitcher.php";
+
+	login_as_account($mybb->user, $mybb->get_input('uid', MyBB::INPUT_INT), $_SERVER['HTTP_REFERER']);
 }
 
 if(($mybb->input['action'] == "register" || $mybb->input['action'] == "do_register") && $mybb->usergroup['cancp'] != 1)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/089fe28d-ef91-458c-8cb4-f9cc4862d423)

In navigation you can see avatars of your character (or you player account). When you click on your account, you are logged in as selected account then redirected to the page you came from.
It does not show character you're currently on (as you can see it above). If you are not logged in as a player - player account is always on the top.
Hovering over avatar shows name of the account.