### PR TITLE
99 allowing for configuration of which group has administrative access to account switcher

### DIFF
--- a/website/admin/modules/user/groups.php
+++ b/website/admin/modules/user/groups.php
@@ -953,7 +953,8 @@ if($mybb->input['action'] == "edit")
 				"caneditprofiles" => $mybb->get_input('caneditprofiles', MyBB::INPUT_INT),
 				"canbanusers" => $mybb->get_input('canbanusers', MyBB::INPUT_INT),
 				"canviewwarnlogs" => $mybb->get_input('canviewwarnlogs', MyBB::INPUT_INT),
-				"canuseipsearch" => $mybb->get_input('canuseipsearch', MyBB::INPUT_INT)
+				"canuseipsearch" => $mybb->get_input('canuseipsearch', MyBB::INPUT_INT),
+				"canAssignAnyUser" => $mybb->get_input('canAssignAnyUser', MyBB::INPUT_INT)
 			);
 
 			// Only update the candisplaygroup setting if not a default user group
@@ -1038,7 +1039,8 @@ if($mybb->input['action'] == "edit")
 		"forums_posts" => $lang->forums_posts,
 		"users_permissions" => $lang->users_permissions,
 		"misc" => $lang->misc,
-		"modcp" => $lang->mod_cp
+		"modcp" => $lang->mod_cp,
+		"bbbcp" => "Własne"
 	);
 	$tabs = $plugins->run_hooks("admin_user_groups_edit_graph_tabs", $tabs);
 	$page->output_tab_control($tabs);
@@ -1268,6 +1270,20 @@ if($mybb->input['action'] == "edit")
 		$form->generate_check_box("canuseipsearch", 1, $lang->can_use_ipsearch, array("checked" => $mybb->input['canuseipsearch']))
 	);
 	$form_container->output_row($lang->user_options, "", "<div class=\"group_settings_bit\">".implode("</div><div class=\"group_settings_bit\">", $user_options)."</div>");
+
+	$form_container->end();
+	echo "</div>";
+
+	//
+	// BBB CP
+	//
+	echo "<div id=\"tab_bbbcp\">";
+	$form_container = new FormContainer($lang->mod_cp);
+
+	$forum_post_options = array(
+		$form->generate_check_box("canAssignAnyUser", 1, "Może przypisać dowolnego użytkownika do posta?", array("checked" => $mybb->input['canAssignAnyUser'])),
+	);
+	$form_container->output_row($lang->forum_post_options, "", "<div class=\"group_settings_bit\">".implode("</div><div class=\"group_settings_bit\">", $forum_post_options)."</div>");
 
 	$form_container->end();
 	echo "</div>";

--- a/website/inc/class_core.php
+++ b/website/inc/class_core.php
@@ -680,6 +680,5 @@ $fpermfields = array(
 	'mod_edit_posts',
 	'canpostpolls',
 	'canvotepolls',
-	'cansearch',
-	'canAssignAnyUser'
+	'cansearch'
 );


### PR DESCRIPTION
We'll be handling permission as they are handled in mybb. All permissions are for groups, not for individual users. Steps for creating new permission:
1. To mybb_usergroups table add new column with valid type. I.e. if permission is simple yes or no (i.e. "can assign any user in account switcher") it should be of type tinyint. Remember to have those changes in db.changelog.xml
Example:
```SQL 
ALTER TABLE mybb_usergroups ADD canAssignAnyUser TINYINT NOT NULL DEFAULT '0' AFTER canuseipsearch;
```
3. To allow for configuring this permission,  modify groups.php. Go to section marked with comment "BBB CP" for example. This is our custom section and it's better if we stick to it. Example:
```PHP
	$forum_post_options = array(
		$form->generate_check_box("canAssignAnyUser", 1, "Może przypisać dowolnego użytkownika do posta?", array("checked" => $mybb->input['canAssignAnyUser'])),
	);
```

<img width="951" height="261" alt="Image" src="https://github.com/user-attachments/assets/a73819e8-c029-453a-af3c-5ba66632836f" />
You also need to update $updated_group in the same file, to read your new permission from input.
 
5. For development - you'll need to refresh cache for the change to catch. After that you can read it from usergroup object. Most common scenario will be checking if current user has this specific permission - almost always it will be accessible through $mybb->usergroup.